### PR TITLE
Fix: Clone direction vector in player movement.

### DIFF
--- a/game.js
+++ b/game.js
@@ -139,14 +139,16 @@ function updatePlayer() {
     }
 
     // Movement (relative to player's direction)
-    const direction = new THREE.Vector3();
-    player.getWorldDirection(direction);
+    const forwardDirection = new THREE.Vector3();
+    player.getWorldDirection(forwardDirection); // Get the forward vector
 
     if (movement.forward) {
-        player.position.add(direction.multiplyScalar(moveSpeed));
+        // Clone before multiplyScalar as it modifies in-place
+        player.position.add(forwardDirection.clone().multiplyScalar(moveSpeed));
     }
     if (movement.backward) {
-        player.position.add(direction.multiplyScalar(-moveSpeed)); // Moving backward
+        // Clone before multiplyScalar as it modifies in-place
+        player.position.add(forwardDirection.clone().multiplyScalar(-moveSpeed));
     }
 
     // Camera follow (simple third-person follow)


### PR DESCRIPTION
I cloned the `forwardDirection` vector before applying scalar multiplication for player movement. This prevents potential issues from in-place vector modification, which could lead to unexpected behavior including inverted controls if the vector was unintentionally modified by a previous operation in the same frame.

This is an attempt to fix the reported issue of inverted forward/backward movement.