### PR TITLE
Fix: Correct inverted player forward/backward movement.

### DIFF
--- a/game.js
+++ b/game.js
@@ -143,12 +143,12 @@ function updatePlayer() {
     player.getWorldDirection(forwardDirection); // Get the forward vector
 
     if (movement.forward) {
-        // Clone before multiplyScalar as it modifies in-place
-        player.position.add(forwardDirection.clone().multiplyScalar(moveSpeed));
+        // Invert the scalar for forward movement
+        player.position.add(forwardDirection.clone().multiplyScalar(-moveSpeed)); 
     }
     if (movement.backward) {
-        // Clone before multiplyScalar as it modifies in-place
-        player.position.add(forwardDirection.clone().multiplyScalar(-moveSpeed));
+        // Use a positive scalar for backward movement (which is forward relative to the inverted direction)
+        player.position.add(forwardDirection.clone().multiplyScalar(moveSpeed));
     }
 
     // Camera follow (simple third-person follow)


### PR DESCRIPTION
Inverted the application of the forwardDirection vector in player movement logic.
- Forward input now moves you opposite to the vector from getWorldDirection.
- Backward input now moves you along the vector from getWorldDirection.

This corrects the issue where your movement was inverted relative to the 'up' and 'down' controls.